### PR TITLE
docs: Added callouts extension to support GitHub style alerts.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM squidfunk/mkdocs-material:9.5
 
 # Install PlantUML so we can render UML diagrams.
-RUN pip install plantuml_markdown
+RUN pip install markdown-callouts plantuml_markdown
 RUN apk add --no-cache plantuml --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community \
     && rm -rf /var/cache/apk/*
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -8,6 +8,7 @@ plugins:
 markdown_extensions:
   - admonition
   - attr_list
+  - github-callouts
   - footnotes
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji


### PR DESCRIPTION
See: https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts